### PR TITLE
[mathematic-check] refactor: move codes to src/mathematica_check and update doc

### DIFF
--- a/servers/mathematica-check/README.md
+++ b/servers/mathematica-check/README.md
@@ -21,12 +21,21 @@ This server acts as a bridge, enabling applications that support MCP to leverage
 
 ## Installation
 
+### Directly way
+```bash
+uvx --from git+https://github.com/pathintegral-institute/mcp.science.git#subdirectory=servers/mathematica-check mcp-mathematica-check
+```
+
+
+### Clone codes to local and use
+
 1.  **Clone the repository (if you haven't already):**
     ```bash
     git clone <repository-url>
     cd <repository-directory>/servers/mathematica-check
     ```
 2.  **Set up the Python environment and install dependencies using `uv`:**
+
     ```bash
     # Create a virtual environment
     uv venv
@@ -47,15 +56,19 @@ To start the MCP server, ensure your virtual environment is activated, and then 
 
 ```bash
 # Using the script defined in pyproject.toml
-mathematica-check
+mcp-mathematica-check
 ```
+
 Or explicitly:
+
 ```bash
-python -m mathematica-check.server
+python -m mathematica_check.server
 ```
+
 Or using the MCP CLI:
+
 ```bash
-mcp run src/server.py
+mcp run src/mathematica_check/server.py
 ```
 
 The server will start and listen for connections from MCP clients via standard input/output (stdio).
@@ -68,18 +81,19 @@ Follow the general steps for integrating MCP servers with your client:
 2.  **Configure Your MCP Client:** Add the server to your client's configuration (e.g., `settings.json` or similar). You'll need to provide the command to run the server within its environment.
 
     Example configuration snippet:
+
     ```json
     {
       "mcpServers": {
         "mathematica-check": {
           // Option 1: Running the installed script (ensure .venv/bin is in PATH or use absolute path)
           "command": "/path/to/your/project/servers/mathematica-check/.venv/bin/mcp-mathematica-check",
-          
+
           // Option 2: Explicitly using python from the venv
           // "command": "/path/to/your/project/servers/mathematica-check/.venv/bin/python",
-          // "args": ["-m", "server"],
+          // "args": ["-m", "mathematica_check.server"],
           // "cwd": "/path/to/your/project/servers/mathematica-check", // Set working directory to the root of mathematica-check
-          
+
           "disabled": false,
           "autoApprove": [] // Optional: Add tool names ("execute_mathematica", "verify_derivation")
         }
@@ -130,7 +144,7 @@ Verifies a sequence of mathematical expressions.
 
 ## Project Structure
 
-*   `src/`: Python source code for the server.
+*   `src/mathematica_check`: Python source code for the server.
     *   `server.py`: Main server logic and tool definitions.
 *   `pyproject.toml`: Project metadata and dependencies (for `uv` and `pip`).
 *   `.python-version`: Specifies the required Python version (used by tools like `pyenv`).

--- a/servers/mathematica-check/pyproject.toml
+++ b/servers/mathematica-check/pyproject.toml
@@ -6,12 +6,10 @@ description = "A Python MCP server for interacting with Mathematica/wolframscrip
 authors = [{ name = "Sirui Lu", email = "sirui.lu.phys@gmail.com" }]
 license = { text = "MIT" }
 
-dependencies = [
-    "mcp[cli]>=1.0.0",
-]
+dependencies = ["mcp[cli]>=1.0.0"]
 
 [project.scripts]
-mcp-mathematica-check = "server:main"
+mcp-mathematica-check = "mathematica_check.server:main"
 
 [build-system]
 requires = ["setuptools>=61.0"]

--- a/servers/mathematica-check/setup.py
+++ b/servers/mathematica-check/setup.py
@@ -1,17 +1,17 @@
-from setuptools import setup, find_namespace_packages
+from setuptools import setup, find_packages
 
 setup(
     name="mathematica-check",
     version="0.1.0",
-    packages=find_namespace_packages(where="src"),
+    packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
     entry_points={
         "console_scripts": [
-            "mcp-mathematica-check=server:main",
+            "mcp-mathematica-check=mathematica_check.server:main",
         ],
     },
     install_requires=[
         "mcp[cli]>=1.0.0",
     ],
-) 
+)

--- a/servers/mathematica-check/src/mathematica_check/__init__.py
+++ b/servers/mathematica-check/src/mathematica_check/__init__.py
@@ -1,3 +1,3 @@
 """
 Mathematica-check package for MCP server.
-""" 
+"""

--- a/servers/mathematica-check/src/mathematica_check/server.py
+++ b/servers/mathematica-check/src/mathematica_check/server.py
@@ -57,7 +57,8 @@ async def check_mathematica_installation() -> bool:
         logger.error("Mathematica (wolframscript) not found in PATH.")
         _mathematica_available = False
     except Exception as e:
-        logger.error(f"Error checking Mathematica installation: {e}", exc_info=True)
+        logger.error(
+            f"Error checking Mathematica installation: {e}", exc_info=True)
         _mathematica_available = False
 
     _mathematica_checked = True
@@ -90,7 +91,8 @@ async def execute_mathematica_code(code: str, format: str = "text") -> str:
             )
 
         if stderr_str:
-            logger.warning(f"Mathematica execution produced stderr: {stderr_str}")
+            logger.warning(
+                f"Mathematica execution produced stderr: {stderr_str}")
 
         logger.info("Mathematica execution completed successfully.")
         return stdout_str
@@ -269,4 +271,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main() 
+    main()


### PR DESCRIPTION
cc @LionSR

the mathematica-check cannot run by `uvx` directly, to let others be able to use it convienently, it's better to create a subdirectory under `src/`

Btw, I created another [PR](https://github.com/pathintegral-institute/mcpm.sh/pull/136) in MCPM repo to add this into MCPM Registry, others can add this MCP server simply by `mcpm add mathematic-check` after it merged