### PR TITLE
[gpaw calculation] improve feedback for failure to LLM

### DIFF
--- a/servers/gpaw-computation/server_package/gpaw_computation_server/gpaw_utils/lib.py
+++ b/servers/gpaw-computation/server_package/gpaw_computation_server/gpaw_utils/lib.py
@@ -231,7 +231,7 @@ def perform_calculation_service(input_info: CalculationInfo,
         input_ckpt_file_path = getattr(input_info, 'ckpt_file_path', None)
         if not input_ckpt_file_path or not os.path.exists(input_ckpt_file_path):
             raise ValueError(
-                "Input ckpt_file_path is empty. A ckpt file with charge density isrequired for band calculation.")
+                "Input ckpt_file_path is empty. A ckpt file with charge density isrequired for band calculation. Maybe run relax or ground_state calculation first.")
         else:
             calc = GPAW(input_ckpt_file_path, txt=None)
             if not hasattr(calc, 'density') or calc.density is None:

--- a/servers/gpaw-computation/src/gpaw_computation/server.py
+++ b/servers/gpaw-computation/src/gpaw_computation/server.py
@@ -190,12 +190,15 @@ async def start_calculation(
         f"-c {output_calculation_id}"
     )
     logger.info(f"Executing command: {shell_command}")
-    execute_command_on_server(shell_command)
+    _, _, stderr = execute_command_on_server(shell_command)
+    stderr_content = stderr.read().decode("utf-8")
 
     result = {
         "calculation_id": output_calculation_id,
         "project_id": project_id,
     }
+    if stderr_content:
+        result["error_log"] = stderr_content
     logger.info(f"Result: {result}")
     return TextContent(type="text", text=json.dumps(result))
 


### PR DESCRIPTION
### **User description**
> 嗯做band calculation之前应该先做relax或者ground state。目前没有hard code这种要求，要么就是在检查到没有ckpt的时候返回一个error message，让模型去跑一下relax or ground state？
Error: no charge density is found in this calculation project. Please do a relax or ground state calculation before computing the band structure.
by xiaoliang

test:
![image](https://github.com/user-attachments/assets/bcf12ccc-79b0-4824-9f2e-9a8e12306a08)


___

### **PR Type**
Enhancement


___

### **Description**
• Improve error message for missing checkpoint files in band calculations
• Add stderr capture and return in calculation results
• Provide clearer guidance to run prerequisite calculations first


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lib.py</strong><dd><code>Improve band calculation error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

servers/gpaw-computation/server_package/gpaw_computation_server/gpaw_utils/lib.py

• Enhanced error message for missing ckpt file in band calculations<br> • <br>Added suggestion to run relax or ground_state calculation first


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcp.science/pull/46/files#diff-7d81435a46938eda0f95e86abb13bf171efb4c3f5a06efe43ac7342707de5749">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>server.py</strong><dd><code>Add error logging to calculation results</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

servers/gpaw-computation/src/gpaw_computation/server.py

• Capture stderr output from command execution<br> • Include error_log in <br>calculation result response


</details>


  </td>
  <td><a href="https://github.com/pathintegral-institute/mcp.science/pull/46/files#diff-ad94fc3cb85d77ffdc237f5966931bf750b471eaa1819eccd2d87d1a5414a806">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>