### PR TITLE
[ssh-exec]fix: ssh authentication improvements

### DIFF
--- a/servers/ssh-exec/README.md
+++ b/servers/ssh-exec/README.md
@@ -33,9 +33,10 @@ For security reasons, SSH credentials should be provided via environment variabl
 - `SSH_PORT`: SSH port (default: 22)
 - `SSH_USERNAME`: SSH username (required)
 - `SSH_PRIVATE_KEY`: SSH private key content (not path)
+- `SSH_PRIVATE_KEY_FILE`: SSH private key file path (supports OpenSSH format)
 - `SSH_PASSWORD`: SSH password
 
-Either `SSH_PRIVATE_KEY` or `SSH_PASSWORD` must be provided, or the system will attempt to use your SSH config.
+Either `SSH_PRIVATE_KEY`, `SSH_PRIVATE_KEY_FILE`, or `SSH_PASSWORD` must be provided, or the system will attempt to use your SSH config. If both `SSH_PRIVATE_KEY` and `SSH_PRIVATE_KEY_FILE` are provided, `SSH_PRIVATE_KEY_FILE` takes precedence.
 
 Optional environment variables for security configuration:
 - `SSH_ALLOWED_COMMANDS`: Comma-separated list of commands that are allowed to be executed
@@ -63,7 +64,10 @@ Optional environment variables for security configuration:
 export SSH_HOST=example.com
 export SSH_PORT=22
 export SSH_USERNAME=user
-export SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
+# Option 1: Use private key file path (recommended for OpenSSH format keys)
+export SSH_PRIVATE_KEY_FILE=~/.ssh/id_rsa
+# Option 2: Use private key content
+# export SSH_PRIVATE_KEY="$(cat ~/.ssh/id_rsa)"
 export SSH_ALLOWED_COMMANDS="ls,ps,cat"
 export SSH_ALLOWED_PATHS="/tmp,/home"
 export SSH_COMMANDS_BLACKLIST=rm,mv,dd,mkfs,fdisk,format
@@ -93,7 +97,7 @@ Use this option if you have the code checked out locally and want to run it dire
         "SSH_HOST": "example.com",
         "SSH_PORT": "22",
         "SSH_USERNAME": "user",
-        "SSH_PRIVATE_KEY": "$(cat ~/.ssh/id_rsa)",
+        "SSH_PRIVATE_KEY_FILE": "~/.ssh/id_rsa",
         "SSH_ALLOWED_COMMANDS": "ls,ps,cat",
         "SSH_ALLOWED_PATHS": "/tmp,/home",
         "SSH_COMMANDS_BLACKLIST": "rm,mv,dd,mkfs,fdisk,format",
@@ -122,7 +126,7 @@ Use this option to automatically fetch and run the latest version from GitHub:
         "SSH_HOST": "example.com",
         "SSH_PORT": "22",
         "SSH_USERNAME": "user",
-        "SSH_PRIVATE_KEY": "$(cat ~/.ssh/id_rsa)",
+        "SSH_PRIVATE_KEY_FILE": "~/.ssh/id_rsa",
         "SSH_ALLOWED_COMMANDS": "ls,ps,cat",
         "SSH_ALLOWED_PATHS": "/tmp,/home",
         "SSH_COMMANDS_BLACKLIST": "rm,mv,dd,mkfs,fdisk,format",

--- a/servers/ssh-exec/src/ssh_exec/server.py
+++ b/servers/ssh-exec/src/ssh_exec/server.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 SSH_HOST = None
 SSH_PORT = 22
 SSH_USERNAME = None
-SSH_PRIVATE_KEY = None
+SSH_PRIVATE_KEY_FILE = None
 SSH_PASSWORD = None
 ALLOWED_COMMANDS = []
 ALLOWED_PATHS = []
@@ -30,7 +30,7 @@ ARGUMENTS_BLACKLIST = []
 def load_env():
     """Load environment variables"""
     global SSH_HOST, SSH_PORT, SSH_USERNAME
-    global SSH_PRIVATE_KEY, SSH_PASSWORD
+    global SSH_PRIVATE_KEY_FILE, SSH_PASSWORD
     global ALLOWED_COMMANDS, ALLOWED_PATHS
     global COMMANDS_BLACKLIST, ARGUMENTS_BLACKLIST
 
@@ -38,7 +38,8 @@ def load_env():
     SSH_HOST = os.environ.get("SSH_HOST")
     SSH_PORT = int(os.environ.get("SSH_PORT", "22"))
     SSH_USERNAME = os.environ.get("SSH_USERNAME")
-    SSH_PRIVATE_KEY = os.environ.get("SSH_PRIVATE_KEY")
+
+    SSH_PRIVATE_KEY_FILE = os.environ.get("SSH_PRIVATE_KEY_FILE")
     SSH_PASSWORD = os.environ.get("SSH_PASSWORD")
 
     # Get security configuration from environment variables
@@ -57,11 +58,12 @@ def load_env():
     logger.info("SSH exec MCP server configuration:")
     logger.info("SSH host: %s", SSH_HOST)
     logger.info("SSH port: %s", SSH_PORT)
-    logger.info("SSH username: %s", SSH_USERNAME)
-    logger.info("Using private key: %s", bool(SSH_PRIVATE_KEY))
+    logger.info("SSH username: %s%s", SSH_USERNAME or "not_set", 
+                " (will use SSH config)" if not SSH_USERNAME else "")
+    logger.info("Using private key file: %s", bool(SSH_PRIVATE_KEY_FILE))
     logger.info("Using password: %s", bool(SSH_PASSWORD))
     logger.info(
-        "Using system SSH config: %s", not SSH_PRIVATE_KEY and not SSH_PASSWORD)
+        "Using SSH config fallback: %s", not SSH_PRIVATE_KEY_FILE and not SSH_PASSWORD)
     logger.info("Allowed commands: %s", ALLOWED_COMMANDS)
     logger.info("Allowed paths: %s", ALLOWED_PATHS)
     logger.info("Commands blacklist: %s", COMMANDS_BLACKLIST)
@@ -111,7 +113,7 @@ def get_ssh_client() -> Optional[SSHClient]:
             host=SSH_HOST,
             port=SSH_PORT,
             username=SSH_USERNAME,
-            private_key=SSH_PRIVATE_KEY,
+            private_key_file=SSH_PRIVATE_KEY_FILE,
             password=SSH_PASSWORD
         )
         logger.info(

--- a/servers/ssh-exec/src/ssh_exec/server.py
+++ b/servers/ssh-exec/src/ssh_exec/server.py
@@ -36,6 +36,9 @@ def load_env():
 
     # Get SSH configuration from environment variables
     SSH_HOST = os.environ.get("SSH_HOST")
+    if not SSH_HOST:
+        raise Exception("ssh host is not set!")
+
     SSH_PORT = int(os.environ.get("SSH_PORT", "22"))
     SSH_USERNAME = os.environ.get("SSH_USERNAME")
 
@@ -92,10 +95,8 @@ def validate_ssh_config() -> None:
     """
     if not SSH_HOST:
         raise ValueError("SSH_HOST environment variable is not set")
-    if not SSH_USERNAME:
-        raise ValueError("SSH_USERNAME environment variable is not set")
-    # Private key and password are now optional
-    # If neither is provided, system SSH configuration will be used
+    # Username is now optional if SSH config is available
+    # Private key and password are optional - will use SSH config or system defaults
 
 
 # Get or create SSH client
@@ -116,9 +117,10 @@ def get_ssh_client() -> Optional[SSHClient]:
             private_key_file=SSH_PRIVATE_KEY_FILE,
             password=SSH_PASSWORD
         )
+        username_display = SSH_USERNAME or "from_ssh_config"
         logger.info(
             "Created SSH client for %s@%s:%s",
-            SSH_USERNAME, SSH_HOST, SSH_PORT)
+            username_display, SSH_HOST, SSH_PORT)
         return ssh_client
     except paramiko.SSHException as e:
         logger.error("Failed to create SSH client: %s", str(e))

--- a/servers/ssh-exec/src/ssh_exec/server.py
+++ b/servers/ssh-exec/src/ssh_exec/server.py
@@ -20,6 +20,7 @@ SSH_HOST = None
 SSH_PORT = 22
 SSH_USERNAME = None
 SSH_PRIVATE_KEY_FILE = None
+SSH_CONFIG_FILE = None
 SSH_PASSWORD = None
 ALLOWED_COMMANDS = []
 ALLOWED_PATHS = []
@@ -30,7 +31,7 @@ ARGUMENTS_BLACKLIST = []
 def load_env():
     """Load environment variables"""
     global SSH_HOST, SSH_PORT, SSH_USERNAME
-    global SSH_PRIVATE_KEY_FILE, SSH_PASSWORD
+    global SSH_PRIVATE_KEY_FILE, SSH_PASSWORD, SSH_CONFIG_FILE
     global ALLOWED_COMMANDS, ALLOWED_PATHS
     global COMMANDS_BLACKLIST, ARGUMENTS_BLACKLIST
 
@@ -44,6 +45,8 @@ def load_env():
 
     SSH_PRIVATE_KEY_FILE = os.environ.get("SSH_PRIVATE_KEY_FILE")
     SSH_PASSWORD = os.environ.get("SSH_PASSWORD")
+
+    SSH_CONFIG_FILE = os.environ.get("SSH_CONFIG_FILE")
 
     # Get security configuration from environment variables
     ALLOWED_COMMANDS = [
@@ -115,7 +118,8 @@ def get_ssh_client() -> Optional[SSHClient]:
             port=SSH_PORT,
             username=SSH_USERNAME,
             private_key_file=SSH_PRIVATE_KEY_FILE,
-            password=SSH_PASSWORD
+            password=SSH_PASSWORD,
+            ssh_config_file=SSH_CONFIG_FILE,
         )
         username_display = SSH_USERNAME or "from_ssh_config"
         logger.info(
@@ -136,7 +140,7 @@ async def ssh_exec(
         description="Arguments to pass to the command")] = None,
     timeout: Annotated[Optional[int], Field(
         description="Timeout in seconds for command execution")] = None
-) -> Tuple[int, str, str]:
+) -> TextContent:
     """Execute a command on the remote system
 
     Args:

--- a/servers/ssh-exec/src/ssh_exec/ssh_client.py
+++ b/servers/ssh-exec/src/ssh_exec/ssh_client.py
@@ -1,8 +1,11 @@
 import io
 import logging
+import os
+from pathlib import Path
 from typing import Optional, Tuple
 
 import paramiko
+from paramiko.config import SSHConfig
 
 logger = logging.getLogger(__name__)
 
@@ -17,6 +20,7 @@ class SSHClient:
         username: Optional[str] = None,
         private_key_file: Optional[str] = None,
         password: Optional[str] = None,
+        ssh_config_file: Optional[str] = None,
     ):
         """Initialize SSH client
 
@@ -26,18 +30,87 @@ class SSHClient:
             username: SSH username (optional if specified in SSH config)
             private_key_file: SSH private key file path
             password: SSH password
+            ssh_config_file: Path to SSH config file (defaults to ~/.ssh/config)
 
         Note:
-            If neither private_key, private_key_file, nor password is provided, the client will attempt
-            to use the system's SSH configuration (e.g., keys in ~/.ssh/)
-            If both private_key and private_key_file are provided, private_key_file takes precedence
+            If username is not provided, it will be read from SSH config
+            If neither private_key_file nor password is provided, the client will attempt
+            to use SSH config identity files or system SSH configuration (e.g., keys in ~/.ssh/)
+            SSH config file is loaded as fallback for missing connection parameters
         """
         self.host = host
         self.port = port
         self.username = username
         self.private_key_file = private_key_file
         self.password = password
+        self.ssh_config_file = ssh_config_file
         self.client = None
+        self._ssh_config = None
+
+    def _get_default_ssh_config_path(self) -> Optional[str]:
+        """Get the default SSH config file path for the current platform."""
+        if os.name == 'nt':  # Windows
+            # Windows SSH config is typically in %USERPROFILE%\.ssh\config
+            config_path = Path.home() / '.ssh' / 'config'
+        else:  # Unix-like (Linux, macOS)
+            config_path = Path.home() / '.ssh' / 'config'
+        
+        return str(config_path) if config_path.exists() else None
+
+    def _load_ssh_config(self) -> Optional[SSHConfig]:
+        """Load SSH config from file."""
+        if self._ssh_config is not None:
+            return self._ssh_config
+
+        config_path = self.ssh_config_file or self._get_default_ssh_config_path()
+        if not config_path:
+            return None
+
+        try:
+            self._ssh_config = SSHConfig.from_path(config_path)
+            logger.debug("Loaded SSH config from %s", config_path)
+            return self._ssh_config
+        except (IOError, OSError) as e:
+            logger.warning(
+                "Could not load SSH config from %s: %s",
+                config_path, str(e)
+            )
+            return None
+
+    def _get_config_for_host(self, hostname: str) -> dict:
+        """Get SSH config settings for a specific hostname."""
+        ssh_config = self._load_ssh_config()
+        if ssh_config:
+            return ssh_config.lookup(hostname)
+        return {}
+
+    def _load_private_key_file(self, key_file_path: str) -> Optional[paramiko.PKey]:
+        """Load private key from file, trying multiple key types."""
+        if not os.path.exists(key_file_path):
+            logger.debug("Key file not found: %s", key_file_path)
+            return None
+
+        key_types = [
+            paramiko.RSAKey,
+            paramiko.Ed25519Key,
+            paramiko.ECDSAKey,
+        ]
+        
+        for key_type in key_types:
+            try:
+                private_key = key_type.from_private_key_file(key_file_path)
+                logger.debug("Loaded %s key from %s", key_type.__name__, key_file_path)
+                return private_key
+            except (paramiko.SSHException, ValueError, OSError):
+                continue
+        logger.warning("Unable to load private key from %s", key_file_path)
+        return None
+
+    def _set_system_auth(self, connect_kwargs: dict) -> None:
+        """Set up system authentication fallback."""
+        logger.info("Using system SSH configuration for authentication")
+        connect_kwargs["look_for_keys"] = True
+        connect_kwargs["allow_agent"] = True
 
     async def connect(self) -> None:
         """Connect to the SSH server"""
@@ -54,45 +127,67 @@ class SSHClient:
                     error=str(e)
                 )
 
+            # Get SSH config settings for this host
+            config_settings = self._get_config_for_host(self.host)
+            
+            # Use SSH config values as fallbacks
+            hostname = config_settings.get('hostname', self.host)
+            port = config_settings.get('port', self.port)
+            username = self.username or config_settings.get('user')
+            
+            # Convert port to int if it's a string from config
+            if isinstance(port, str):
+                port = int(port)
+                
+            # Username is required for SSH connection
+            if not username:
+                raise paramiko.SSHException(
+                    f"No username specified for host {self.host}. "
+                    "Please provide username parameter or configure it in SSH config."
+                )
+
             connect_kwargs = {
-                "hostname": self.host,
-                "port": self.port,
-                "username": self.username,
+                "hostname": hostname,
+                "port": port,
+                "username": username,
             }
 
+            # Handle authentication - check explicit params first, then SSH config
             if self.private_key_file:
-                # Use private key file path - supports OpenSSH format
-                # Try different key types in order
-                private_key = None
-                key_types = [
-                    paramiko.RSAKey,
-                    paramiko.Ed25519Key,
-                    paramiko.ECDSAKey,
-                ]
+                # Use explicitly provided private key file
+                private_key = self._load_private_key_file(self.private_key_file)
+                if private_key:
+                    connect_kwargs["pkey"] = private_key
+            elif self.password:
+                # Use explicitly provided password
+                connect_kwargs["password"] = self.password
+            elif config_settings.get('identityfile'):
+                # Try SSH config identity files
+                identity_files = config_settings.get('identityfile')
+                if isinstance(identity_files, str):
+                    identity_files = [identity_files]
                 
-                for key_type in key_types:
-                    try:
-                        private_key = key_type.from_private_key_file(self.private_key_file)
+                private_key = None
+                for identity_file in identity_files:
+                    # Expand ~ to home directory
+                    identity_file = os.path.expanduser(identity_file)
+                    private_key = self._load_private_key_file(identity_file)
+                    if private_key:
+                        connect_kwargs["pkey"] = private_key
                         break
-                    except (paramiko.SSHException, ValueError):
-                        continue
                 
                 if not private_key:
                     # Fall back to system authentication
                     self._set_system_auth(connect_kwargs)
             else:
-                # If neither private_key nor password is provided, use system SSH config
-                # This will use keys from ~/.ssh/ if available
-                logger.info(
-                    "Using system SSH configuration for authentication")
-                connect_kwargs["look_for_keys"] = True
-                connect_kwargs["allow_agent"] = True
+                # If nothing is explicitly configured, use system SSH config
+                self._set_system_auth(connect_kwargs)
 
             self.client.connect(**connect_kwargs)
             logger.info(
                 "Connected to SSH server %s:%s",
-                self.host,
-                self.port
+                connect_kwargs["hostname"],
+                connect_kwargs["port"]
             )
         except paramiko.SSHException as e:
             logger.error(
@@ -107,9 +202,7 @@ class SSHClient:
             self.client.close()
             self.client = None
             logger.info(
-                "Disconnected from SSH server %s:%s",
-                self.host,
-                self.port
+                "Disconnected from SSH server"
             )
 
     async def execute_command(

--- a/servers/ssh-exec/src/ssh_exec/ssh_client.py
+++ b/servers/ssh-exec/src/ssh_exec/ssh_client.py
@@ -49,11 +49,7 @@ class SSHClient:
 
     def _get_default_ssh_config_path(self) -> Optional[str]:
         """Get the default SSH config file path for the current platform."""
-        if os.name == 'nt':  # Windows
-            # Windows SSH config is typically in %USERPROFILE%\.ssh\config
-            config_path = Path.home() / '.ssh' / 'config'
-        else:  # Unix-like (Linux, macOS)
-            config_path = Path.home() / '.ssh' / 'config'
+        config_path = Path.home() / '.ssh' / 'config'
         
         return str(config_path) if config_path.exists() else None
 

--- a/servers/ssh-exec/uv.lock
+++ b/servers/ssh-exec/uv.lock
@@ -375,44 +375,6 @@ cli = [
 ]
 
 [[package]]
-name = "mcp-ssh-exec"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "fastapi" },
-    { name = "mcp", extra = ["cli"] },
-    { name = "paramiko" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "ruff" },
-    { name = "uvicorn" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "black" },
-    { name = "isort" },
-    { name = "pyright" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=23.9.1" },
-    { name = "fastapi", specifier = ">=0.104.0" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.5.0" },
-    { name = "paramiko", specifier = ">=3.4.0" },
-    { name = "pydantic", specifier = ">=2.5.0" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.389" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "ruff", specifier = ">=0.11.2" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.3" },
-    { name = "uvicorn", specifier = ">=0.23.0" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -724,6 +686,44 @@ sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b4
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
 ]
+
+[[package]]
+name = "ssh-exec"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "mcp", extra = ["cli"] },
+    { name = "paramiko" },
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "ruff" },
+    { name = "uvicorn" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "isort" },
+    { name = "pyright" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=23.9.1" },
+    { name = "fastapi", specifier = ">=0.104.0" },
+    { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.5.0" },
+    { name = "paramiko", specifier = ">=3.4.0" },
+    { name = "pydantic", specifier = ">=2.5.0" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.389" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "ruff", specifier = ">=0.11.2" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.3" },
+    { name = "uvicorn", specifier = ">=0.23.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "starlette"


### PR DESCRIPTION
## 1. Replace SSH_PRIVATE_KEY with SSH_PRIVATE_KEY_FILE

since the openssh is not supported for `SSH_PRIVATE_KEY`

```python
>>> key = """-----BEGIN OPENSSH PRIVATE KEY-----xxx-----END OPENSSH PRIVATE KEY-----"""
>>> paramiko.RSAKey.from_private_key(io.StringIO(key))
SSHException: not a valid RSA private key file
```

while 
```
>>> paramiko.RSAKey.from_private_key_file(id_rsa_path)
```
is ok

## 2. Use system ssh config as default

Thus, users can use this MCP server with only specifying `SSH_HOST`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH config file support (automatic or custom), hostname aliases, port/user overrides, and key-file authentication. New env vars: SSH_PRIVATE_KEY_FILE and SSH_CONFIG_FILE; SSH_USERNAME may be optional when config provides it. Default port 22 supported.

* **Bug Fixes / Validation**
  * SSH_HOST is now required and validated. Explicit auth precedence established (private-key-file, password, config identity files, system agent).

* **Documentation**
  * Expanded examples and usage flows, plus SSH_ALLOWED_COMMANDS env var and cross-platform notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->